### PR TITLE
Expose enablePermissionDialog on <locar-camera> and pass it to DeviceOrientationControls

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # locar-aframe.js 
 
-**PR16 branch version - untested on iOS devices. Requires `locar.js` from the PR16 branch, version `0.0.13-pre3`. You may need to edit the path to the tarball for this version of `locar.js` by editing the `package.json`.**
-
 Location-based AR from AR.js - A-Frame components.
 
 A-Frame components include: 
@@ -30,11 +28,12 @@ Must be added to an A-Frame camera entity e.g. `<a-camera>` or `<a-entity camera
 
 Parameters:
 
-- `simulateLatitude`    (number) - fake latitude to use
-- `simulateLongitude`   (number) - fake latitude to use
-- `simulateAltitude`    (number) - fake altitude to use
-- `positionMinAccuracy` (number) - minimum accuracy in metres for GPS positions to be accepted.
-- `smoothingFactor`     (number) - smoothing factor for sensors, the same concept as in original AR.js.
+- `simulateLatitude`      (number)  - fake latitude to use
+- `simulateLongitude`     (number)  - fake latitude to use
+- `simulateAltitude`      (number)  - fake altitude to use
+- `positionMinAccuracy`   (number)  - minimum accuracy in metres for GPS positions to be accepted.
+- `smoothingFactor`       (number)  - smoothing factor for sensors, the same concept as in original AR.js.
+- `enablePermissionDialog`(boolean) - decides if device orientation permission dialog is shown on iOS devices.
 
 ## locar-entity-place
 

--- a/lib/aframe/locar-camera.js
+++ b/lib/aframe/locar-camera.js
@@ -30,6 +30,10 @@ AFRAME.registerComponent("locar-camera", {
         smoothingFactor: {
             type: "number",
             default: 1
+        },
+        enablePermissionDialog: {
+            type: "boolean",
+            default: true
         }
     },
 
@@ -48,7 +52,12 @@ AFRAME.registerComponent("locar-camera", {
         });
 
         if(this._isMobile()) {
-            this.deviceOrientationControls = new DeviceOrientationControls(this.el.object3D, { smoothingFactor: this.data.smoothingFactor});
+            this.deviceOrientationControls = new DeviceOrientationControls(
+                this.el.object3D,
+                { 
+                    smoothingFactor: this.data.smoothingFactor,
+                    enablePermissionDialog: this.data.enablePermissionDialog
+            });
 
             this.deviceOrientationControls.on("deviceorientationgranted", ev => {
                 ev.target.connect();


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Previously, the new `enablePermissionDialog` parameter was not present in the `locar-camera.js` file.
This is fixed by adding it to the `schema` and `if(this._isMobile())` clause.
This change ensures consistency with the other parameter `smoothingFactor` that is handled in the same way.


**Can it be referenced to an Issue? If so what is the issue # ?**

This is related to Issue [#17](https://github.com/AR-js-org/locar.js/issues/17) from the locar.js Repository, which introduces `version 0.1.0`.


**How can we test it?**

Examples 1-6 from the locar.js Repository are still working as this Pull Request introduces no breaking changes.


**Summary**

See above.


**Does this PR introduce a breaking change?**

No, the change secures consitency with the new locar.js `version 0.1.0`.


**Please TEST your PR before proposing it. Specify here what device you have used for tests, version of OS and version of Browser**

- **Android T-Phone** (Android 14), Chrome Version 130
- **iPhone 14 Pro** (iOS 18.5), Chrome Version 139 & Safari Version 18


**Other information**

The README was updated as well to reflect this change.










